### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 3
   target-branch: master
   reviewers:
@@ -15,7 +15,7 @@ updates:
 - package-ecosystem: composer
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 3
   target-branch: master
   reviewers:
@@ -27,7 +27,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 3
   target-branch: master
   reviewers:
@@ -39,7 +39,7 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 3
   target-branch: master
   reviewers:
@@ -51,7 +51,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 3
   target-branch: master
   reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+  
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 3
+  target-branch: master
+  reviewers:
+    - echarrod
+    - LAFYoti
+    - jlmartyres
+    - nikhilPank
+


### PR DESCRIPTION
## Why 
- We have automated security fixes created (e.g. https://github.com/getyoti/yoti-sign-examples/pull/7), but these don't get addressed as no one is assigned them, or a review requested. Also by default, dependabot doesn't scan multiple package managers, so this config file would mean we scan each example. 

- At the moment, we have reviewers. I _think_ we can set PRs to automatically merge if CI checks pass. But since we don't have CI checks on this repo, I don't know if this would be a good idea.   
- Current schedule is monthly, 3 PRs max. Security update PRs are created immediately though, and are excluded from this update schedule

I'll do the same for https://github.com/getyoti/age-scan-examples if this is all good