### PR TITLE
NA: Update Go API Demo to use go.mod file, add .gitignore

### DIFF
--- a/api-demos/go/.gitignore
+++ b/api-demos/go/.gitignore
@@ -1,0 +1,7 @@
+# Output binary
+api-demo
+
+# Example project generated self-signed certificate
+yotiSelfSignedCert.pem
+yotiSelfSignedKey.pem
+

--- a/api-demos/go/go.mod
+++ b/api-demos/go/go.mod
@@ -1,0 +1,7 @@
+module api-demo
+
+go 1.16
+
+require (
+	github.com/joho/godotenv v1.3.0
+)

--- a/api-demos/go/go.sum
+++ b/api-demos/go/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=


### PR DESCRIPTION
- Add go.mod
  - this allows us to include the dependencies needed to run the project, so it is simpler for clients